### PR TITLE
Add PKS compatible Micro Integrator Helm chart

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,26 @@
 *.zip
 *.tar.gz
 *.rar
-
+*.tgz
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
+
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,377 @@
 # pks-micro-integrator
+
 This repository contains Micro Integrator Pivotal PKS artifact resources.
+
+# Prerequisites
+
+* An already setup [Pivotal Application service(PAS) (v2.7.1)](https://network.pivotal.io/products/elastic-runtime#/releases/477769)
+* An already setup [Pivotal Container Service(PKS) (v1.5.1)](https://network.pivotal.io/products/pivotal-container-service#/releases/481414)
+* Install [NGINX Ingress Controller](https://kubernetes.github.io/ingress-nginx/deploy/) version [nginx-0.22.0](https://github.com/kubernetes/ingress-nginx/releases/tag/nginx-0.22.0) on the PKS provisioned Kubernetes cluster
+* An already setup [Pivotal Container Service Manager(KSM) (v0.5.1)](https://network.pivotal.io/products/container-services-manager#/releases/493270) 
+* An already setup [VMware Harbor Registry (v1.8.3)](https://network.pivotal.io/products/harbor-container-registry#/releases/470132) 
+
+>In the context of this document,
+
+> **PKS_MICRO_INTEGRATOR_HOME** will refer to a local copy of the wso2/pks-micro-integrator Git repository.
+
+# Build the PKS compatible Micro Integrator Helm chart
+
+1. Clone PKS Resources for WSO2 Micro Integrator Git repository.
+
+    `https://github.com/wso2/pks-micro-integrator.git`
+
+1. Goto PKS_MICRO_INTEGRATOR_HOME/helm/micro-integrator directory.
+
+    `cd PKS_MICRO_INTEGRATOR_HOME/helm/micro-integrator`
+
+1. Build the Micro Integrator Helm chart with the following command
+   
+    ```helm package .```
+
+# Configuring Micro Integrator on PKS
+
+1. Push docker images to the private registry	
+    ```
+    docker pull wso2/micro-integrator:1.1.0
+    docker tag wso2/micro-integrator:1.1.0  PRIVATE_DOCKER_REGISTRY_DOMAIN/PROJECT/micro-integrator:1.1.0
+    docker push PRIVATE_DOCKER_REGISTRY_DOMAIN/PROJECT/micro-integrator:1.1.0
+    
+    docker pull busybox:1.31
+    docker tag busybox:1.31 PRIVATE_DOCKER_REGISTRY_DOMAIN/PROJECT/busybox:1.31
+    docker push PRIVATE_DOCKER_REGISTRY_DOMAIN/PROJECT/busybox:1.31 
+    ```
+   Where:
+    * **PRIVATE_DOCKER_REGISTRY_DOMAIN** refers to the docker registry domain used by PKS.
+    * **PROJECT** refers to the Harbor private docker registry project that is configured for the Pivotal KSM(Container Services Manager for Pivotal Platform -> Settings -> Container Registry Configuration -> Registry Server URL).
+
+1.
+    1. Setup Micro Integrator Service on Pivotal KSM
+        1. Install the [KSM CLI](https://network.pivotal.io/products/container-services-manager#/releases/493270/file_groups/2225)
+        1. Configure KSM CLI using the [Pivotal KSM documentation](https://docs.pivotal.io/ksm/0-5/using.html)
+        1. Enable Service Offering Access
+            1. Log in to your PAS deployment by running the following command:
+            
+                `cf login -a API-URL -u USERNAME -p PASSWORD`
+           
+               Where:
+                * **API-URL** is the API endpoint for your PAS instance.
+                * **USERNAME** is your username for your PAS instance.
+                * **PASSWORD** is your password for your PAS instance.
+
+            1. Enable access to the Micro Integrator service for all organizations by running the following command:
+                
+                `cf enable-service-access micro-integrator`
+            1. View the newly created Micro Integrator service plans by running the following command:
+                
+                `cf marketplace`
+                    
+    Please find more information on using KSM [here](https://docs.pivotal.io/ksm/0-5/using.html).
+
+# Micro Integrator service plans
+
+Micro Integrator service comes with two plans which represent the resources allocated for a Micro integrator service instance:
+* Small [CPU = 1000m, Memory = 1Gi]
+* Medium [CPU = 2000m, Memory = 2Gi]
+
+# Deploy Micro Integrator service instance
+
+### Burning Carbon Application(CApp) into Micro Integrator base image
+
+In this approach, the CApp is burnt into the Micro integrator docker image .Thereafter the image is referenced when deploying the Micro integrator service instance
+
+1. Creating the Micro Integrator Docker image
+    1. Create a file named Dockerfile with the following content 
+        ```
+           FROM wso2/micro-integrator:1.1.0
+           ARG CAPP_LOCATION
+           COPY  ${CAPP_LOCATION} /home/wso2carbon/wso2mi/repository/deployment/server/carbonapps
+        ```
+    
+    1. Copy the CApp to the same directory where the Dockerfile is located.
+    1. Build the Docker image with the following command:
+    
+        `docker build -t PRIVATE_DOCKER_REGISTRY_DOMAIN/PROJECT/IMAGE_NAME:1.1.0 --build-arg CAPP_LOCATION=./CAPP_FILE .`
+        
+        Where:
+         * **PRIVATE_DOCKER_REGISTRY_DOMAIN** refers to the docker registry domain used by PKS.
+         * **PROJECT** refers to the Harbor private docker registry project that is configured for the Pivotal KSM(Container Services Manager for Pivotal Platform -> Settings -> Container Registry Configuration -> Registry Server URL).
+         * **IMAGE_NAME** is the name of the docker image.
+         * **CAPP_FILE** is the CApp file name(Ex: HelloWorld.car).
+     
+    1. Push the docker image to the private registry with the following command:
+    
+        `docker push PRIVATE_DOCKER_REGISTRY_DOMAIN/PROJECT/IMAGE_NAME:1.1.0 `
+
+1. Create a file(params.json) which contains parameters for Micro integrator service instance 
+    ```
+    {
+    "images": {
+     "microIntegrator": {
+       "image": "PRIVATE_DOCKER_REGISTRY_DOMAIN/PROJECT/IMAGE_NAME"
+     }
+    },
+     "ingress": {
+       "host": "HOST_NAME"
+     }
+    }
+    ```
+    Where:
+     * **PRIVATE_DOCKER_REGISTRY_DOMAIN** refers to the docker registry domain used by PKS.
+     * **PROJECT** refers to the Harbor private docker registry project that is configured for the Pivotal KSM(Container Services Manager for Pivotal Platform -> Settings -> Container Registry Configuration -> Registry Server URL).
+     * **IMAGE_NAME** is the name of the docker image.
+     * **HOST_NAME** is the Ingress hostname for Micro integrator service instance. 
+     
+1. Create Micro Integrator Service Instance by running the following command:
+    ```
+    cf create-service micro-integrator PLAN SERVICE_INSTANCE_NAME -c params.json
+    ```
+    Where:
+    
+      * **PLAN** is the Micro integrator service plan(small or medium).
+      * **SERVICE_INSTANCE_NAME** is the service instance name.
+      * **params.json** is a file that contains parameters for the Micro integrator service instance. 
+
+1. Create a service key for the Micro-integrator by running the following command:
+
+    `cf create-service-key SERVICE_INSTANCE_NAME  KEY_NAME`
+    
+    Where:
+      * **SERVICE_INSTANCE_NAME** is the service instance name.
+      * **KEY_NAME** is the service key name.
+
+1. Get the service key content with the following command:
+
+   `cf service-key SERVICE_INSTANCE_NAME  KEY_NAME`
+   
+    Where:
+     * **SERVICE_INSTANCE_NAME** is the service instance name.
+     * **KEY_NAME** is the service key name.
+    
+    Example output:
+    ```      
+    {
+     "hostname": "HOSTNAME",
+     "namespace": "NAMESPACE",
+     "releaseName": "RELEASE_NAME"
+    }
+    ```
+
+1. Configure a hostname mapping to point **HOSTNAME** to Ingress controller Loadbalancer.
+
+1. Invoke the Micro Integrator service instance as shown below
+
+    `curl https://HOSTNAME/servies/SERVICE`
+
+### Hosting CApp in a remote location
+
+In this method, the CApp is hosted in a remote location and the location is passed as a parameter when deploying the Micro integrator service instance.
+
+1. Create a file(params.json) which contains parameters for Micro integrator service instance 
+    ```
+    {
+     "capp": {
+       "urls": "CAPP_FILE_LOCATION"
+     },
+     "ingress": {
+       "host": "HOST_NAME"
+     }
+    }
+    ```
+    Where:
+     * **CAPP_FILE_LOCATION**  is the CApp file remote location(Ex: https://download.com/helloworld.capp).
+     * **HOST_NAME** is the Ingress hostname for Micro integrator service instance. 
+     
+1. Create Micro Integrator Service Instance by running the following command:
+    ```
+    cf create-service micro-integrator PLAN SERVICE_INSTANCE_NAME -c params.json
+    ```
+    Where:
+    
+      * **PLAN** is the Micro integrator service plan(small or medium).
+      * **SERVICE_INSTANCE_NAME** is the service instance name.
+      * **params.json** is a file that contains parameters for the Micro integrator service instance. 
+
+1. Create a service key for the Micro-integrator by running the following command:
+
+    `cf create-service-key SERVICE_INSTANCE_NAME  KEY_NAME`
+    
+    Where:
+      * **SERVICE_INSTANCE_NAME** is the service instance name.
+      * **KEY_NAME** is the service key name.
+
+1. Get the service key content with the following command:
+
+   `cf service-key SERVICE_INSTANCE_NAME  KEY_NAME`
+   
+    Where:
+     * **SERVICE_INSTANCE_NAME** is the service instance name.
+     * **KEY_NAME** is the service key name.
+    
+    Example output:
+    ```aidl      
+    {
+     "hostname": "HOSTNAME",
+     "namespace": "NAMESPACE",
+     "releaseName": "RELEASE_NAME"
+    }
+    ```
+
+1. Configure a hostname mapping to point **HOSTNAME** to Ingress controller Loadbalancer.
+
+1. Invoke the Micro Integrator service instance as shown below
+
+    `curl https://HOSTNAME/servies/SERVICE`
+
+# Override Micro Integrator default configurations
+
+The configuration file of the Micro Integrator is located at MICRO_INTEGRATOR_HOME/conf/deployment.tom.l In the above
+ location  MICRO_INTEGRATOR_HOME  refers to unzipped Micro Integrator distribution. There are two ways to provide this
+  configuration file to a Micro integrator service instance.
+
+
+### Burning configuration file into Micro Integrator base image
+
+In accordance with this approach, the deployment.toml file is burnt into the Micro integrator docker image itself.
+The image is referenced when deploying the Micro integrator service instance.
+
+
+1. Creating the Micro Integrator Docker image
+    1. Create a file named Dockerfile with the following content 
+        ```
+        FROM wso2/micro-integrator:1.1.0
+        ARG CONFIG_LOCATION
+        COPY  ${CONFIG_LOCATION} /home/wso2carbon/wso2mi/conf/
+        ```
+        This step can be combined with the Burning CApp into Micro Integrator base Docker image step.  
+    1. Copy the deployment.toml to the same directory where the Dockerfile is located.
+    1. Build the Docker image with the following command:
+    
+        `docker build -t PRIVATE_DOCKER_REGISTRY_DOMAIN/PROJECT/IMAGE_NAME:1.1.0 --build-arg CONFIG_LOCATION=./deployment.toml .`
+        
+        Where:
+         * **PRIVATE_DOCKER_REGISTRY_DOMAIN** refers to the docker registry domain used by PKS.
+         * **PROJECT** refers to the Harbor private docker registry project that is configured for the Pivotal KSM(Container Services Manager for Pivotal Platform -> Settings -> Container Registry Configuration -> Registry Server URL).
+         * **IMAGE_NAME** is the name of the docker image.
+         * **CONFIG_LOCATION** is the deployment.toml file path.
+     
+    1. Push the docker image to the private registry with the following command:
+    
+        `docker push PRIVATE_DOCKER_REGISTRY_DOMAIN/PROJECT/IMAGE_NAME:1.1.0 `
+
+1. Create a file(params.json) which contains parameters for Micro integrator service instance 
+    ```
+    {
+    "images": {
+     "microIntegrator": {
+       "image": "PRIVATE_DOCKER_REGISTRY_DOMAIN/PROJECT/IMAGE_NAME"
+     }
+    },
+     "ingress": {
+       "host": "HOST_NAME"
+     }
+    }
+    ```
+    Where:
+     * **PRIVATE_DOCKER_REGISTRY_DOMAIN** refers to the docker registry domain used by PKS.
+     * **PROJECT** refers to the Harbor private docker registry project that is configured for the Pivotal KSM(Container Services Manager for Pivotal Platform -> Settings -> Container Registry Configuration -> Registry Server URL).
+     * **IMAGE_NAME** is the name of the docker image.
+     * **HOST_NAME** is the Ingress hostname for Micro integrator service instance. 
+     
+1. Create Micro Integrator Service Instance by running the following command:
+    ```
+    cf create-service micro-integrator PLAN SERVICE_INSTANCE_NAME -c params.json
+    ```
+    Where:
+    
+      * **PLAN** is the Micro integrator service plan(small or medium).
+      * **SERVICE_INSTANCE_NAME** is the service instance name.
+      * **params.json** is a file that contains parameters for the Micro integrator service instance. 
+
+1. Create a service key for the Micro-integrator by running the following command:
+
+    `cf create-service-key SERVICE_INSTANCE_NAME  KEY_NAME`
+    
+    Where:
+      * **SERVICE_INSTANCE_NAME** is the service instance name.
+      * **KEY_NAME** is the service key name.
+
+1. Get the service key content with the following command:
+
+   `cf service-key SERVICE_INSTANCE_NAME  KEY_NAME`
+   
+    Where:
+     * **SERVICE_INSTANCE_NAME** is the service instance name.
+     * **KEY_NAME** is the service key name.
+    
+    Example output:
+    ```    
+    {
+     "hostname": "HOSTNAME",
+     "namespace": "NAMESPACE",
+     "releaseName": "RELEASE_NAME"
+    }
+    ```
+
+1. Configure a hostname mapping to point **HOSTNAME** to Ingress controller Loadbalancer.
+
+1. Invoke the Micro Integrator service instance as shown below
+
+    `curl https://HOSTNAME/servies/SERVICE`
+
+### Hosting the Configuration file in a remote location
+
+In this approach, the deployment.toml is hosted in a remote location and the location is passed as a parameter when deploying the Micro integrator service instance.
+
+1. Create a file(params.json) which contains parameters for Micro integrator service instance 
+    ```
+    {
+     "ingress": {
+       "host": "HOST_NAME"
+     },
+     "deploymentTomlURL": "CONFIG_FILE_REMOTE_LOCATION"
+    }
+    ```
+    Where:
+     * **HOST_NAME** is the Ingress hostname for Micro integrator service instance. 
+     * **CONFIG_FILE_REMOTE_LOCATION**openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout key -out cert -subj "/CN=*.maanadev.com/O=wso2"openssl x509 -in cert -text -noout is the deployment.toml file remote location(Ex: https://download.com/deplyment.toml).
+     
+1. Create Micro Integrator Service Instance by running the following command:
+    ```
+    cf create-service micro-integrator PLAN SERVICE_INSTANCE_NAME -c params.json
+    ```
+    Where:
+    
+      * **PLAN** is the Micro integrator service plan(small or medium).
+      * **SERVICE_INSTANCE_NAME** is the service instance name.
+      * **params.json** is a file that contains parameters for the Micro integrator service instance. 
+
+1. Create a service key for the Micro-integrator by running the following command:
+
+    `cf create-service-key SERVICE_INSTANCE_NAME  KEY_NAME`
+    
+    Where:
+      * **SERVICE_INSTANCE_NAME** is the service instance name.
+      * **KEY_NAME** is the service key name.
+
+1. Get the service key content with the following command:
+
+   `cf service-key SERVICE_INSTANCE_NAME  KEY_NAME`
+   
+    Where:
+     * **SERVICE_INSTANCE_NAME** is the service instance name.
+     * **KEY_NAME** is the service key name.
+    
+    Example output:
+    ```      
+    {
+     "hostname": "HOSTNAME",
+     "namespace": "NAMESPACE",
+     "releaseName": "RELEASE_NAME"
+    }
+    ```
+
+1. Configure a hostname mapping to point **HOSTNAME** to Ingress controller Loadbalancer.
+
+1. Invoke the Micro Integrator service instance as shown below
+
+    `curl https://HOSTNAME/servies/SERVICE`

--- a/helm/micro-integrator/Chart.yaml
+++ b/helm/micro-integrator/Chart.yaml
@@ -1,0 +1,18 @@
+# Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: v1
+appVersion: "1.1.0"
+description: A Helm chart for WSO2 Micro Integrator
+name: micro-integrator
+version: 0.1.0

--- a/helm/micro-integrator/bind.yaml
+++ b/helm/micro-integrator/bind.yaml
@@ -1,0 +1,20 @@
+# Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+template: |
+  {
+    hostname:  $.services[0].metadata.labels["nginx.ingress.hostname"],
+    releaseName: $.services[0].metadata.labels["app.kubernetes.io/instance"],
+    namespace: $.services[0].metadata.namespace
+  }

--- a/helm/micro-integrator/plans.yaml
+++ b/helm/micro-integrator/plans.yaml
@@ -1,0 +1,19 @@
+# Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+- name: "small"
+  description: "default (small) plan for WSO2 Micro Integrator"
+  file: "small.yaml"
+- name: "medium"
+  description: "medium sized plan for WSO2 Micro Integrator"
+  file: "medium.yaml"

--- a/helm/micro-integrator/plans/medium.yaml
+++ b/helm/micro-integrator/plans/medium.yaml
@@ -1,0 +1,18 @@
+# Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+resources:
+  requests:
+    cpu: 2000m
+    memory: 2Gi

--- a/helm/micro-integrator/plans/small.yaml
+++ b/helm/micro-integrator/plans/small.yaml
@@ -1,0 +1,18 @@
+# Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+resources:
+  requests:
+    cpu: 1000m
+    memory: 1Gi

--- a/helm/micro-integrator/templates/NOTES.txt
+++ b/helm/micro-integrator/templates/NOTES.txt
@@ -1,0 +1,1 @@
+Thank you for installing WSO2 Micro Integrator.

--- a/helm/micro-integrator/templates/_helpers.tpl
+++ b/helm/micro-integrator/templates/_helpers.tpl
@@ -1,0 +1,57 @@
+{{/*
+Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/}}
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "micro-integrator.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "micro-integrator.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "micro-integrator.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "micro-integrator.labels" -}}
+app.kubernetes.io/name: {{ include "micro-integrator.name" . }}
+helm.sh/chart: {{ include "micro-integrator.chart" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}

--- a/helm/micro-integrator/templates/deployment.yaml
+++ b/helm/micro-integrator/templates/deployment.yaml
@@ -1,0 +1,127 @@
+# Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "micro-integrator.fullname" . }}
+  labels:
+{{ include "micro-integrator.labels" . | indent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  minReadySeconds: {{ .Values.minReadySeconds }}
+  strategy:
+    rollingUpdate:
+      maxSurge: {{ .Values.strategy.rollingUpdate.maxSurge }}
+      maxUnavailable: {{ .Values.strategy.rollingUpdate.maxUnavailable }}
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "micro-integrator.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "micro-integrator.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+    spec:
+      securityContext:
+       runAsUser: 802
+    {{- if or (not (eq .Values.capp.urls "")) (not (eq .Values.deploymentTomlURL ""))}}
+      initContainers:
+      {{- if not (eq .Values.capp.urls "") }}
+        - name: init-download-capps
+          image: "{{ .Values.images.initContainer.image }}:{{ .Values.images.initContainer.imageTag }}"
+          command:
+            - /bin/sh
+            - "-c"
+            - |
+              set -e
+              wget -P /capps {{ .Values.capp.urls }}
+          volumeMounts:
+            - name: capp-download
+              mountPath: /capps
+      {{- end }}
+      {{- if not (eq .Values.deploymentTomlURL "") }}
+        - name: init-download-deployment-toml
+          image: "{{ .Values.images.initContainer.image }}:{{ .Values.images.initContainer.imageTag }}"
+          command:
+              - /bin/sh
+              - "-c"
+              - |
+                  set -e
+                  wget -P /conf {{ .Values.deploymentTomlURL }}
+          volumeMounts:
+              - name: deployment-toml-download
+                mountPath: /conf
+      {{- end }}
+    {{- end }}
+    {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.images.microIntegrator.image }}:{{ .Values.images.microIntegrator.imageTag }}"
+          imagePullPolicy: {{ .Values.images.microIntegrator.pullPolicy }}
+        {{- if not (eq .Values.deploymentTomlURL "") }}
+          command:
+            - /bin/sh
+            - "-c"
+            - |
+                set -e
+                cp /home/wso2carbon/conf/deployment.toml /home/wso2carbon/wso2mi/conf/
+                /home/wso2carbon/wso2mi/bin/micro-integrator.sh
+        {{- end}}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+              protocol: TCP
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - nc -z localhost {{ .Values.service.port }}
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+          readinessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - nc -z localhost {{ .Values.service.port }}
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- if or (not (eq .Values.capp.urls "")) (not (eq .Values.deploymentTomlURL ""))}}
+          volumeMounts:
+          {{- if not (eq .Values.capp.urls "") }}
+            - name: capp-download
+              mountPath: /home/wso2carbon/wso2mi/repository/deployment/server/carbonapps
+          {{- end }}
+          {{- if not (eq .Values.deploymentTomlURL "") }}
+            - name: deployment-toml-download
+              mountPath: /home/wso2carbon/conf
+          {{- end }}
+      volumes:
+      {{- if not (eq .Values.capp.urls "") }}
+        - name: capp-download
+          emptyDir: {}
+      {{- end}}
+      {{- if not (eq .Values.deploymentTomlURL "") }}
+        - name: deployment-toml-download
+          emptyDir: {}
+      {{- end }}
+    {{- end }}

--- a/helm/micro-integrator/templates/ingress.yaml
+++ b/helm/micro-integrator/templates/ingress.yaml
@@ -1,0 +1,43 @@
+# Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{{ if .Values.ingress.enabled }}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+{{ $fullName := include "micro-integrator.fullname" . }}
+  name: {{ $fullName }}
+  labels:
+{{ include "micro-integrator.labels" . | indent 4 }}
+  annotations:
+    kubernetes.io/ingress.class: nginx
+  {{- with .Values.ingress.annotations }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  tls:
+    - hosts:
+        - {{ .Values.ingress.host }}
+    {{- if .Values.ingress.secret }}
+      secretName: {{ .Values.ingress.secret }}
+    {{- end }}
+  rules:
+    - host: {{ .Values.ingress.host }}
+      http:
+        paths:
+          - path: /
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: {{ .Values.service.port }}
+{{ end }}

--- a/helm/micro-integrator/templates/service.yaml
+++ b/helm/micro-integrator/templates/service.yaml
@@ -1,0 +1,30 @@
+# Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "micro-integrator.fullname" . }}
+  labels:
+    "nginx.ingress.hostname": {{ .Values.ingress.host }}
+{{ include "micro-integrator.labels" . | indent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: {{ include "micro-integrator.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}

--- a/helm/micro-integrator/values.yaml
+++ b/helm/micro-integrator/values.yaml
@@ -1,0 +1,73 @@
+# Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# number of Micro Integrator pods
+replicaCount: 1
+
+images:
+  microIntegrator:
+    image: "wso2/micro-integrator"
+    imageTag: "1.1.0"
+    pullPolicy: IfNotPresent
+  initContainer:
+    image: "busybox"
+    imageTag: "1.31"
+
+capp:
+  # remote localtion for CApp
+  urls: ""
+
+#imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+livenessProbe:
+  initialDelaySeconds: 35
+  periodSeconds: 10
+
+readinessProbe:
+  initialDelaySeconds: 35
+  periodSeconds: 10
+
+minReadySeconds: 35
+
+strategy:
+  rollingUpdate:
+    maxSurge: 1
+    maxUnavailable: 0
+
+service:
+  # Micro Integrator service type
+  type: ClusterIP
+  # Micro Integrator service port
+  port: 8290
+
+ingress:
+  # enable an ingress to expose. If enabled, must set the service type to "ClusterIP".
+  enabled: true
+  # annotations for Ingress 
+  annotations: {}
+  # Host name of the ingress
+  host: "{{ .Release.Name }}.example.com"
+#  secret: ""
+
+resources:
+  limits:
+    cpu: 2000m
+    memory: 2Gi
+  requests:
+    cpu: 1000m
+    memory: 1Gi
+# deployment.toml remote location 
+deploymentTomlURL: ""


### PR DESCRIPTION
## Purpose
> Add initial PKS compatible Micro Integrator Helm chart artifact resources
fixes #2 
## Test environment
> Pivotal Application service(PAS) (v2.7.1)
Pivotal Container Service(PKS) (v1.5.1)]
NGINX Ingress Controller version [nginx-0.22.0](https://github.com/kubernetes/ingress-nginx/releases/tag/nginx-0.22.0) on the PKS provisioned Kubernetes cluster
Pivotal Container Service Manager(KSM) (v0.5.1)
VMware Harbor Registry (v1.8.3)
